### PR TITLE
Read both {energy,charge}_now and {energy,charge}_full to determine battery status

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -72,6 +72,12 @@ void read_acpi_battery(int b, struct batt_info *bi) {
 	long int energy_full = 0;
 	sprintf(path, "%s/BAT%d/energy_full", PS_PATH, b);
 	f = fopen(path, "r");
+	
+	if(f == NULL) {
+		sprintf(path, "%s/BAT%d/charge_full", PS_PATH, b);
+		f = fopen(path, "r");
+	}
+  
 	if(f == NULL || fgets(energy_full_s, 32, f) == NULL) {
 		fprintf(stderr, "%scould not read battery energy max: '%s'\n",
 				BAD_MSG, path);
@@ -84,6 +90,12 @@ void read_acpi_battery(int b, struct batt_info *bi) {
 	long int energy_now = 0;
 	sprintf(path, "%s/BAT%d/energy_now", PS_PATH, b);
 	f = fopen(path, "r");
+  
+	if(f == NULL) {
+		sprintf(path, "%s/BAT%d/charge_now", PS_PATH, b);
+		f = fopen(path, "r");
+	}  
+
 	if(f == NULL || fgets(energy_now_s, 32, f) == NULL) {
 		fprintf(stderr, "%scould not read battery energy now: '%s'\n",
 				BAD_MSG, path);


### PR DESCRIPTION
lifebar uses the following files to determine the battery status: 
- `/sys/class/power_supply/BAT0/energy_full`
- `/sys/class/power_supply/BAT0/energy_new` 

According to [this thread](http://comments.gmane.org/gmane.linux.acpi.devel/51602) on the Linux ACPI Development Discussion List there are probably other files available under certain circumstances: 
- `/sys/class/power_supply/BAT0/charge_full`
- `/sys/class/power_supply/BAT0/charge_new` 

This pull request now covers both `energy_*` and `charge_*` files.
What do you think?
